### PR TITLE
Do not warn if newsrv is undefined

### DIFF
--- a/lib/Net/Whois/Raw.pm
+++ b/lib/Net/Whois/Raw.pm
@@ -204,10 +204,12 @@ sub recursive_whois {
     }
 
     if (
-        # Bypass recursing to custom servers
-        $Net::Whois::Raw::Data::whois_servers_no_recurse{ $newsrv }
-        # Bypass recursing to WHOIS servers with no IDN support
-        || $dom =~ /^xn--/i && $newsrv && $Net::Whois::Raw::Data::whois_servers_with_no_idn_support{ $newsrv }
+        defined $newsrv && (
+            # Bypass recursing to custom servers
+            $Net::Whois::Raw::Data::whois_servers_no_recurse{ $newsrv }
+            # Bypass recursing to WHOIS servers with no IDN support
+            || $dom =~ /^xn--/i && $newsrv && $Net::Whois::Raw::Data::whois_servers_with_no_idn_support{ $newsrv }
+        )
     ) {
         $newsrv = undef;
     }


### PR DESCRIPTION
Currently, if `$newsrv` is not defined for this check, the following warning is outputted:

```
Use of uninitialized value $newsrv in hash element at /opt/perl5.24.0/lib/site_perl/5.24.0/Net/Whois/Raw.pm line 206.
```