### PR TITLE
update whois server for second level MX domains

### DIFF
--- a/lib/Net/Whois/Raw/Data.pm
+++ b/lib/Net/Whois/Raw/Data.pm
@@ -765,9 +765,9 @@ our %servers = qw(
     ORG.MA      whois.iam.net.ma
     PRESS.MA    whois.iam.net.ma
 
-    COM.MX      whois.nic.mx
-    GOB.MX      whois.nic.mx
-    NET.MX      whois.nic.mx
+    COM.MX      whois.mx
+    GOB.MX      whois.mx
+    NET.MX      whois.mx
 
     COM.MT      whois.nic.mt
     ORG.MT      whois.nic.mt


### PR DESCRIPTION
Some second level .MX domains still point to an incorrect WHOIS server.