### PR TITLE
Use more detailed error message if constructor fails

### DIFF
--- a/lib/Net/Whois/Raw.pm
+++ b/lib/Net/Whois/Raw.pm
@@ -308,7 +308,7 @@ sub whois_query {
 
             unless ( $sock ) {
                 $sock = IO::Socket::IP->new( @sockparams )
-                    or die "$srv: $!: " . join( ', ', @sockparams );
+                    or die "$srv: $IO::Socket::errstr: " . join( ', ', @sockparams );
             }
 
             if ($class->can ('whois_socket_fixup')) {


### PR DESCRIPTION
Currently, if socket construction fails, the exception uses the message in `$!`. Because this error message comes from the last system call, it has less information that the specific message in `$IO::Socket::errstr`.

I recommend changing to use `$IO::Socket::errstr` to populate the exception if the socket cannot be created.

From the [docs](https://metacpan.org/pod/IO::Socket::IP#Timeout-=%3E-NUM) of `IO::Socket::IP`:

> If the constructor fails, it will set `$IO::Socket::errstr` and `$@` to an appropriate error message; this may be from `$!` or it may be some other string.

As an example, if the domain name of a WHOIS server cannot be resolved (e.g. `whois.tonic.to`), the message in `$!` is `Invalid argument`, whereas `$IO::Socket::errstr` is `Name or service not known`. The latter indicates a DNS error, whereas the former is difficult to understand.